### PR TITLE
Fix recursive deletion of directory not possible

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -401,7 +401,7 @@ class FtpClient implements Countable
 
             // remove children
             foreach ($files as $file) {
-                $this->remove($file, true);
+                $this->remove($directory.'/'.$file, true);
             }
         }
 


### PR DESCRIPTION
The current implementation of "rmdir" is not able to recursively remove a directory.

If the "recursive" flag is set, a file list of the given directory is created (via nlist) and the loop deletes all these files. I think the directory is missing in this call if no "chdir" is performed.

In my case my working directory was "/" and I called "rmdir" with the Parameters "/test-folder" and "true". The folder contained files and directories, so this function didn't delete anything although the recursive flag was set to "true".